### PR TITLE
JBB-74. Bucket Helper.  Fix get_missed_standardized_files gaps detection

### DIFF
--- a/common/bucket_helpers/__init__.py
+++ b/common/bucket_helpers/__init__.py
@@ -204,7 +204,7 @@ def get_missed_standardized_files(  # pylint:disable=too-many-arguments
 
     gaps = (
         date_range.range.select(["dates", "hours"])
-        .join(blb_df, on="hours", how="inner")
+        .join(blb_df, on="hours", how="anti")
         .unique(subset=["hours"])
     )
 


### PR DESCRIPTION
## Description
Updated get_missed_standardized_files to correct detect absent hours
    between expected hours of a meter and real detected files

## Motivation and Context
Described in [JBB-77](https://jbb-platform.youtrack.cloud/issue/JBB-77)

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation as needed.
- [ ] I have added tests to cover my changes.
- [ ] Unit test code coverage is at least 90%
- [ ] All new and existing tests passed.
